### PR TITLE
fixed typo in item migrations with category

### DIFF
--- a/backend/data/dev/migrations/20190214003313_item.js
+++ b/backend/data/dev/migrations/20190214003313_item.js
@@ -14,7 +14,7 @@ exports.up = function(knex, Promise) {
         table.date('purchasedOn');
 
         // will eventually be a foreign key when category table is created
-        table.string('category', 255).references('id').inTable('categories');
+        table.string('category', 255).references('category').inTable('categories');
 
         // timestamps the moment of user creation (i.e. registration date)
         table.timestamp('createdAt').defaultTo(knex.fn.now());


### PR DESCRIPTION
## About

I made a typo in updating the items migration with setting up the categories foreign key. I fixed it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [x] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Needs to be tested with PG as SQLite3 returned no errors with foreign keys. As of right now, I do not have a PG server running to test locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts