### PR TITLE
Hotfix for SQLite3/PostgreSQL contingency

### DIFF
--- a/backend/routes/group/groupRouter.js
+++ b/backend/routes/group/groupRouter.js
@@ -421,7 +421,7 @@ groupRouter.delete('/remove/:groupID/:userID', (req, res) => {
     let groupID = req.params.groupID;
     groupMembersDb.getById(groupID, userID).then(entry => {
         // console.log(entry);
-        if(entry && entry[0].moderator === 1){
+        if(entry && (entry[0].moderator === 1 || entry[0].moderator === true)){
             groupDb.remove(groupID).then(response => {
                 console.log('delete response', response);
                 // delete from groupmembers table


### PR DESCRIPTION
Adds a bit of conditional logic to ensure that the `moderator` check can function properly whether the database value is `1`(SQLite) or `true`(Postgres), as JavaScript parses these differently.