### PR TITLE
ensure checkout passes purchasedOn as a date and not a string

### DIFF
--- a/frontend/shopping-list/src/store/actions/rootActions.js
+++ b/frontend/shopping-list/src/store/actions/rootActions.js
@@ -896,7 +896,7 @@ export const checkOut = info => {
     groupID: Number(info.groupId),
     itemID: Number(itemIds[0]),
     total: Number(info.amount),
-    purchasedOn: moment().format(),
+    purchasedOn: moment().toDate(),
   }
 
 
@@ -904,7 +904,7 @@ export const checkOut = info => {
   for(let i = 0; i < items.length; i++){
     items[i].purchased = 1;
     items[i].purchasedBy = Number(info.userId);
-    items[i].purchasedOn = moment().format();
+    items[i].purchasedOn = moment().toDate();
 
     // console.log('items[i]', items[i]);
     axios.put(`${backendURL}/api/item/${items[i].id}`, items[i], options).then(res => {


### PR DESCRIPTION
Hotfix to make sure the `purchasedOn` type is `date` and not `string` when passing to the database.

Will attempt to fix the timestamp issues we're seeing on the deployed version. I predict it's a Postgres parsing the date but not the time properly since it's a string instead of a date object.